### PR TITLE
feat(blog): add basic blogging support with admin pages

### DIFF
--- a/docs/blogging.md
+++ b/docs/blogging.md
@@ -1,0 +1,16 @@
+# Blogging Feature
+
+This project ships with a lightweight blogging system built on Prisma and Next.js.
+
+- **Model**: `BlogPost` holds a title and markdown content along with timestamps.
+- **API**: `/api/blog` provides JSON endpoints to list and create posts.
+- **Admin Pages**:
+  - `/admin/blog` lists existing entries.
+  - `/admin/blog/new` presents a form to author new posts.
+
+After updating the schema, remember to run Prisma migrations so the database
+includes the `BlogPost` table:
+
+```
+npx prisma migrate dev
+```

--- a/prisma/migrations/20250628083900_create_blog_posts/migration.sql
+++ b/prisma/migrations/20250628083900_create_blog_posts/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "BlogPost" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "BlogPost_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,3 +59,15 @@ model Task {
     name             String
     updatedAt        DateTime           @updatedAt
 }
+
+/// BlogPost stores markdown blog entries authored via the admin UI.
+/// Fields capture basic metadata and full content while tracking
+/// creation and update timestamps. This is intentionally minimal and
+/// can be extended with slugs or publication state if needed.
+model BlogPost {
+    id        String   @id @default(cuid())
+    title     String
+    content   String   @db.Text
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+}

--- a/src/app/admin/blog/new/page.tsx
+++ b/src/app/admin/blog/new/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * Admin interface for authoring a new blog post.
+ *
+ * The component provides a minimal form for entering a title and
+ * markdown content. Submission persists the post through the blog
+ * API and then redirects back to the index view.
+ */
+import { Button, Container, Stack, TextField } from "@mui/material";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export default function NewBlogPostPage() {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  // Send the form data to the API and navigate away on success.
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch("/api/blog", {
+      method: "POST",
+      body: JSON.stringify({ title, content }),
+    });
+    router.push("/admin/blog");
+  }
+
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={2}>
+          <TextField
+            label="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <TextField
+            label="Content"
+            multiline
+            minRows={4}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+          <Button type="submit" variant="contained">
+            Save
+          </Button>
+        </Stack>
+      </form>
+    </Container>
+  );
+}

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Admin blog index page.
+ *
+ * Presents a minimal listing of all blog posts so editors can
+ * quickly verify existing content. The component retrieves posts
+ * from the API on mount and renders basic metadata for each entry.
+ */
+import { Container, Stack, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
+interface BlogPost {
+  id: string;
+  title: string;
+  updatedAt: string;
+}
+
+export default function AdminBlogIndexPage() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+
+  // Load posts once the component mounts.
+  useEffect(() => {
+    async function loadPosts() {
+      const response = await fetch("/api/blog");
+      const allPosts = await response.json();
+      setPosts(allPosts);
+    }
+    loadPosts();
+  }, []);
+
+  return (
+    <Container>
+      <Stack spacing={2}>
+        <Typography variant="h3">Blog Posts</Typography>
+        {posts.map((post) => (
+          <Typography key={post.id}>
+            {post.title} - updated at {post.updatedAt}
+            <br />
+            <small>{post.id}</small>
+          </Typography>
+        ))}
+      </Stack>
+    </Container>
+  );
+}

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -1,0 +1,30 @@
+/**
+ * Blog API route.
+ *
+ * Exposes minimal JSON endpoints for listing existing blog posts and
+ * creating new ones. Keeping this file small prevents circular
+ * dependencies and makes the data flow between the frontend and
+ * Prisma clear.
+ */
+import { prisma } from "@/modules/prisma/lib/prisma-client/prisma-client";
+import { NextRequest, NextResponse } from "next/server";
+
+// Retrieve all blog posts in reverse chronological order.
+export async function GET() {
+  const posts = await prisma.blogPost.findMany({
+    orderBy: { createdAt: "desc" },
+  });
+  return NextResponse.json(posts);
+}
+
+// Persist a new blog post using data from the request body.
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const post = await prisma.blogPost.create({
+    data: {
+      title: data.title,
+      content: data.content,
+    },
+  });
+  return NextResponse.json(post);
+}


### PR DESCRIPTION
## Summary
- add `BlogPost` Prisma model and migration
- expose `/api/blog` endpoints
- provide admin pages for listing and creating blog posts
- document blogging feature

## Testing
- `npm run lint`
- `npm run build` *(fails: PostsPage is not a valid Page export field)*

------
https://chatgpt.com/codex/tasks/task_e_68a840f4cb70832ca9aa6911277ecfbf